### PR TITLE
Add Prometheus and Grafana setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # ConfigRepository
+
+This repository contains configuration files for a Spring Cloud Gateway service.
+It also includes an example monitoring stack using Prometheus and Grafana.
+
+## Files
+
+- `gateway-service.yml` - Gateway route configuration.
+- `api-gateway-service.yml` - Alternative gateway config.
+- `docker-compose.yml` - Compose file for Prometheus and Grafana.
+- `prometheus.yml` - Prometheus scrape configuration.
+
+## Running Prometheus and Grafana
+
+Launch the monitoring stack using Docker Compose:
+
+```bash
+docker compose up -d
+```
+
+Prometheus will be available at `http://localhost:9090` and Grafana at
+`http://localhost:3000` (login with `admin` / `admin`). The Prometheus
+configuration scrapes the gateway's `/actuator/prometheus` endpoint. Ensure
+that the gateway service exposes this endpoint by enabling Spring Boot Actuator
+and including `management.endpoints.web.exposure.include=prometheus` in its
+properties.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.8'
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'gateway'
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ['host.docker.internal:9090']


### PR DESCRIPTION
## Summary
- document gateway configuration
- add docker-compose stack for Prometheus and Grafana
- include Prometheus scrape config

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f43e5ad1083239ec09048a34ce17b